### PR TITLE
chore: rename to @adfinis/semantic-release-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![npm version](https://badge.fury.io/js/%40adfinis-sygroup%2Fsemantic-release-config.svg)](https://badge.fury.io/js/%40adfinis-sygroup%2Fsemantic-release-config)
+[![npm version](https://badge.fury.io/js/%40adfinis%2Fsemantic-release-config.svg)](https://badge.fury.io/js/%40adfinis%2Fsemantic-release-config)
 
-# @adfinis-sygroup/semantic-release-config
+# @adfinis/semantic-release-config
 
 Sharable configuration for [semantic release](https://semantic-release.gitbook.io).
 
@@ -15,14 +15,14 @@ Currently, this config is only a slight modification of the default config:
 Install the npm package
 
 ```bash
-yarn add --dev @adfinis-sygroup/semantic-release-config
+yarn add --dev @adfinis/semantic-release-config
 ```
 
 and add the following to the `extends` property of your [semantic release configuration](https://semantic-release.gitbook.io/semantic-release/usage/configuration#configuration-file):
 
 ```json
 {
-  "extends": "@adfinis-sygroup/semantic-release-config"
+  "extends": "@adfinis/semantic-release-config"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
-  "name": "@adfinis-sygroup/semantic-release-config",
+  "name": "@adfinis/semantic-release-config",
   "version": "3.4.0",
   "description": "Shared semantic release configuration for Adfinis projects",
   "main": "release.config.js",
   "author": "Adfinis AG <info@adfinis.com>",
-  "repository": "github:adfinis-sygroup/semantic-release-config",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adfinis/semantic-release-config"
+  },
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
BREAKING CHANGE: This package was renamed from
`@adfinis-sygroup/semantic-release-config` to
`@adfinis/semantic-release-config`